### PR TITLE
Adds group_id to allowed sample keys

### DIFF
--- a/src/Sample.js
+++ b/src/Sample.js
@@ -182,6 +182,7 @@ define(['helpers', 'Occurrence', 'Collection', 'Events'], function () {
                 }
             },
             location_name: { id: 'location_name' },
+            group: { id: 'group_id' },
             deleted: { id: 'deleted' }
         };
 


### PR DESCRIPTION
This allows a sample to post the record’s activity into the
sample:group_id field.